### PR TITLE
Resolviendo bug de imágenes y optimización de la app

### DIFF
--- a/DragonBallSwift/View/WikiViews/Components/BasicCharacterCardView.swift
+++ b/DragonBallSwift/View/WikiViews/Components/BasicCharacterCardView.swift
@@ -13,27 +13,22 @@ struct BasicCharacterCardView: View {
     
     var body: some View {
         ZStack {
-            VStack {
+            LazyVStack(alignment: .trailing) {
                 AsyncImage(url: URL(string: character.image)) { image in
                     image
                         .resizable()
                         .scaledToFit()
-                        .offset(x: 60, y: 30)
+                        .offset(x: 10, y: 30)
+                        .frame(width: 120, height: 120)
+                        .scaleEffect(1.5)
                 } placeholder: {
-                    HStack{
-                        GifImage("tumblr_5d02caa6c1505584156a309d7c38a5d5_ef84c56e_250")
-                            .scaledToFit()
-                            .frame(width: 50, height: 50)
-                            .offset(x: 100, y: -36)
-                        Text("Please wait ...")
-                            .foregroundStyle(.white).offset(x: 95, y: -30)
+                    ZStack {
                         ProgressView()
+                            .padding(.trailing, 20)
                     }
-
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-            .scaleEffect(2)
+            .frame(maxWidth: .infinity, alignment: .trailing)
             
             VStack {
                 Text(character.name)


### PR DESCRIPTION
### Qué resuelve: 

- [x] Resuelve el bug que mostraba algunas imagenes fuera de la tarjeta, no permitiendo que algunos personajes se mostrasen. 
- [x] Optimiza la carga de imágenes asíncronas para utilizar menos recursos: Se eliminan los gifs de los placeholders de la carga de imágenes asíncronas. Debido a que por cada tarjeta se carga un GIF, y cada GIF es un WebView la aplicación se volvía lenta al momento de renderizar las imágenes. 


| Antes   | Ahora   |
|---|---|
| ![Simulator Screenshot - iPhone 15 Pro - 2024-07-27 at 00 52 47](https://github.com/user-attachments/assets/2de473ce-3e76-4c51-88be-4b656fc0540d) | ![Simulator Screenshot - iPhone 15 Pro - 2024-07-27 at 14 49 51](https://github.com/user-attachments/assets/f2d20830-20c2-4d1a-b934-3982abcf4e79) |


